### PR TITLE
UF-17206 Cannot create new templates

### DIFF
--- a/src/main/java/se/sundsvall/templating/integration/db/entity/TemplateContentEntity.java
+++ b/src/main/java/se/sundsvall/templating/integration/db/entity/TemplateContentEntity.java
@@ -2,6 +2,7 @@ package se.sundsvall.templating.integration.db.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
@@ -23,10 +24,10 @@ import lombok.NoArgsConstructor;
 public class TemplateContentEntity {
 
 	@Id
-	@Column(name = "id")
+	@Column(name = "id", nullable = false)
 	private String id;
 
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "id")
 	@MapsId
 	private TemplateEntity template;

--- a/src/main/java/se/sundsvall/templating/integration/db/entity/TemplateEntity.java
+++ b/src/main/java/se/sundsvall/templating/integration/db/entity/TemplateEntity.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
@@ -22,7 +24,6 @@ import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,7 +49,8 @@ public class TemplateEntity {
 
 	@Id
 	@Column(name = "id", nullable = false, unique = true)
-	private final String id = UUID.randomUUID().toString();
+	@GeneratedValue(strategy = GenerationType.UUID)
+	private String id;
 
 	@Column(name = "identifier", nullable = false)
 	private String identifier;
@@ -79,7 +81,7 @@ public class TemplateEntity {
 	@JoinColumn(name = "template_id", referencedColumnName = "id")
 	private Set<DefaultValueEntity> defaultValues;
 
-	@OneToOne(mappedBy = "template", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+	@OneToOne(mappedBy = "template", cascade = CascadeType.ALL, orphanRemoval = true)
 	private TemplateContentEntity content;
 
 	@Column(name = "changelog")
@@ -93,17 +95,14 @@ public class TemplateEntity {
 	 */
 	@Builder(setterPrefix = "with")
 	TemplateEntity(final String identifier, final String municipalityId, final TemplateType type, final String name,
-		final String description, final String content, final String changeLog,
+		final String description, final String changeLog, final TemplateContentEntity templateContentEntity,
 		final List<MetadataEntity> metadata, final Set<DefaultValueEntity> defaultValues) {
 		this.identifier = identifier;
 		this.municipalityId = municipalityId;
 		this.type = type;
 		this.name = name;
 		this.description = description;
-		this.content = TemplateContentEntity.builder()
-			.withTemplate(this)
-			.withContent(content)
-			.build();
+		this.content = templateContentEntity;
 		this.changeLog = changeLog;
 		this.metadata = metadata;
 		this.defaultValues = defaultValues;

--- a/src/main/java/se/sundsvall/templating/service/TemplateService.java
+++ b/src/main/java/se/sundsvall/templating/service/TemplateService.java
@@ -17,6 +17,7 @@ import se.sundsvall.templating.api.domain.TemplateRequest;
 import se.sundsvall.templating.api.domain.TemplateResponse;
 import se.sundsvall.templating.domain.KeyValue;
 import se.sundsvall.templating.integration.db.DbIntegration;
+import se.sundsvall.templating.integration.db.entity.TemplateContentEntity;
 import se.sundsvall.templating.integration.db.entity.TemplateEntity;
 import se.sundsvall.templating.integration.db.entity.Version;
 import se.sundsvall.templating.service.mapper.TemplateMapper;
@@ -72,6 +73,12 @@ public class TemplateService {
 
 		var templateEntity = mapper.toTemplateEntity(templateRequest, municipalityId)
 			.withVersion(version);
+		var templateContentEntity = TemplateContentEntity.builder()
+			.withId(templateEntity.getId())
+			.withTemplate(templateEntity)
+			.withContent(templateRequest.getContent())
+			.build();
+		templateEntity.setContent(templateContentEntity);
 
 		return mapper.toTemplateResponse(dbIntegration.saveTemplate(templateEntity));
 	}

--- a/src/main/java/se/sundsvall/templating/service/mapper/TemplateMapper.java
+++ b/src/main/java/se/sundsvall/templating/service/mapper/TemplateMapper.java
@@ -30,7 +30,6 @@ public class TemplateMapper {
 			.withType(getTemplateType(decodeBase64(templateRequest.getContent())))
 			.withName(templateRequest.getName())
 			.withDescription(templateRequest.getDescription())
-			.withContent(templateRequest.getContent())
 			.withChangeLog(templateRequest.getChangeLog())
 			.withMetadata(Optional.ofNullable(templateRequest.getMetadata()).orElse(List.of()).stream()
 				.map(metadata -> MetadataEntity.builder()

--- a/src/test/java/se/sundsvall/templating/integration/db/entity/TemplateEntityTests.java
+++ b/src/test/java/se/sundsvall/templating/integration/db/entity/TemplateEntityTests.java
@@ -10,9 +10,12 @@ class TemplateEntityTests {
 	@Test
 	void getContentBytes() {
 		var content = "someContent";
+		var contentEntity = TemplateContentEntity.builder()
+			.withContent(content)
+			.build();
 
 		var templateEntity = TemplateEntity.builder()
-			.withContent(content)
+			.withTemplateContentEntity(contentEntity)
 			.build();
 
 		assertThat(templateEntity.getContentBytes()).isEqualTo(content.getBytes(UTF_8));

--- a/src/test/java/se/sundsvall/templating/service/mapper/TemplateMapperTests.java
+++ b/src/test/java/se/sundsvall/templating/service/mapper/TemplateMapperTests.java
@@ -11,6 +11,7 @@ import se.sundsvall.templating.api.domain.Metadata;
 import se.sundsvall.templating.api.domain.TemplateRequest;
 import se.sundsvall.templating.integration.db.entity.DefaultValueEntity;
 import se.sundsvall.templating.integration.db.entity.MetadataEntity;
+import se.sundsvall.templating.integration.db.entity.TemplateContentEntity;
 import se.sundsvall.templating.integration.db.entity.TemplateEntity;
 
 class TemplateMapperTests {
@@ -31,7 +32,6 @@ class TemplateMapperTests {
 		assertThat(templateEntity).isNotNull();
 		assertThat(templateEntity.getName()).isEqualTo("someName");
 		assertThat(templateEntity.getDescription()).isEqualTo("someDescription");
-		assertThat(templateEntity.getContent()).isEqualTo("someContent");
 		assertThat(templateEntity.getMetadata()).hasSameSizeAs(request.getMetadata());
 		assertThat(templateEntity.getDefaultValues()).hasSameSizeAs(request.getDefaultValues());
 	}
@@ -43,13 +43,14 @@ class TemplateMapperTests {
 
 	@Test
 	void test_toTemplateResponse() {
+		var templateContentEntity = new TemplateContentEntity();
 		var templateEntity = TemplateEntity.builder()
 			.withIdentifier("someIdentifier")
 			.withName("someName")
 			.withDescription("someDescription")
 			.withMetadata(List.of(MetadataEntity.builder().build()))
 			.withDefaultValues(Set.of(DefaultValueEntity.builder().build()))
-			.withContent("someContent")
+			.withTemplateContentEntity(templateContentEntity)
 			.build();
 
 		var templateResponse = mapper.toTemplateResponse(templateEntity);
@@ -70,13 +71,16 @@ class TemplateMapperTests {
 
 	@Test
 	void test_toDetailedTemplateResponse() {
+		var templateContentEntity = TemplateContentEntity.builder()
+			.withContent(encodeBase64("someContent"))
+			.build();
 		var templateEntity = TemplateEntity.builder()
 			.withIdentifier("someIdentifier")
 			.withName("someName")
 			.withDescription("someDescription")
 			.withMetadata(List.of(MetadataEntity.builder().build()))
 			.withDefaultValues(Set.of(DefaultValueEntity.builder().build()))
-			.withContent(encodeBase64("someContent"))
+			.withTemplateContentEntity(templateContentEntity)
 			.build();
 
 		var detailedTemplateResponse = mapper.toDetailedTemplateResponse(templateEntity);


### PR DESCRIPTION
* Updated the way templateContentEntity is set when a new template is created. The previous setup was causing double inserts of the template in the template table which in turn caused issues with the unique constraint

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
